### PR TITLE
feat: register template-desktop-electron as a child

### DIFF
--- a/sync-config.yml
+++ b/sync-config.yml
@@ -12,6 +12,7 @@ tier: 0
 children:
   - EdwardRosenberg/template-backend-java
   - EdwardRosenberg/template-backend-python
+  - EdwardRosenberg/template-desktop-electron
 
 sync_paths:
   - .github/workflows/ci.yml


### PR DESCRIPTION
Register the new Electron desktop template as a direct child of template-base in sync-config.yml.

This enables the platform sync workflow to propagate governance files to the Electron template.